### PR TITLE
Adding BufferRelease call also if skipDTCConfig is set

### DIFF
--- a/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
+++ b/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
@@ -174,7 +174,11 @@ mu2e::Mu2eSubEventReceiver::Mu2eSubEventReceiver(fhicl::ParameterSet const& ps)
 														   cfoConfig.get<bool>("useCFODRP", false));
 	}
 
-	if (skip_dtc_init_) return;  // skip any control of DTC
+	if (skip_dtc_init_) 
+	{
+		theInterface_->ReleaseAllBuffers(DTC_DMA_Engine_DAQ);
+		return; // skip any control of DTC	
+	}
 
 	if (ps.get<bool>("load_sim_file", false))
 	{

--- a/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
+++ b/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
@@ -174,10 +174,10 @@ mu2e::Mu2eSubEventReceiver::Mu2eSubEventReceiver(fhicl::ParameterSet const& ps)
 														   cfoConfig.get<bool>("useCFODRP", false));
 	}
 
-	if (skip_dtc_init_) 
+	if (skip_dtc_init_)
 	{
 		theInterface_->ReleaseAllBuffers(DTC_DMA_Engine_DAQ);
-		return; // skip any control of DTC	
+		return;  // skip any control of DTC
 	}
 
 	if (ps.get<bool>("load_sim_file", false))


### PR DESCRIPTION
This should help to recover if the previous run failed, aka DR were sent but not read by the software. In this case, the buffers are still filled. We want to clean them out at any restart of the BR. The same was already present, just not in the case where skipDTCConfig was set. 