### PR TITLE
CFO subrun handling and logging

### DIFF
--- a/artdaq-mu2e/Generators/CFODataReceiver_generator.cc
+++ b/artdaq-mu2e/Generators/CFODataReceiver_generator.cc
@@ -11,7 +11,20 @@
 #include "artdaq/DAQdata/Globals.hh"
 #include "artdaq/Generators/GeneratorMacros.hh"
 
+#include "artdaq-core-mu2e/Overlays/CFO_Packets/CFO_EventRecord.h"
+#include "artdaq-core-mu2e/Overlays/DTC_Types/DTC_EventMode.h"
+
+#include <libpq-fe.h>
+
+#include <atomic>
+#include <condition_variable>
 #include <fstream>
+#include <iomanip>
+#include <map>
+#include <mutex>
+#include <queue>
+#include <sstream>
+#include <thread>
 
 #include "trace.h"
 #define TRACE_NAME "CFODataReceiver"
@@ -58,11 +71,64 @@ private:
 
 	std::size_t const throttle_usecs_;
 	std::size_t rollover_subrun_interval_;
-	bool rollover_transition_;
 	std::condition_variable throttle_cv_;
 	std::mutex throttle_mutex_;
 	int diagLevel_;
 	std::map<uint64_t, int> ewts_;  // for checking if an event window tag has been found before
+
+	// Per-subrun record
+	struct SubrunRecord
+	{
+		int      subrun_number{-1};
+		uint64_t n_events{0};
+		uint64_t n_on_spill{0};
+		uint64_t n_off_spill{0};
+		uint64_t n_null{0};
+		uint64_t min_ewt{uint64_t(-1)};
+		uint64_t max_ewt{0};
+		uint32_t start_time_unix{0};    // linux_timestamp of first event
+		uint32_t stop_time_unix{0};     // linux_timestamp of last event
+		std::map<uint64_t, uint64_t> event_mode_counts;  // raw event_mode value -> count
+
+		void reset(int subrun)
+		{
+			subrun_number     = subrun;
+			n_events          = 0;
+			n_on_spill        = 0;
+			n_off_spill       = 0;
+			n_null            = 0;
+			min_ewt           = uint64_t(-1);
+			max_ewt           = 0;
+			start_time_unix   = 0;
+			stop_time_unix    = 0;
+			event_mode_counts.clear();
+		}
+	};
+
+	SubrunRecord  subrun_record_;
+
+	// File output
+	std::string   subrun_record_dir_;
+	std::ofstream subrun_record_file_;
+
+	void openRecordFile_();
+	void writeRecordToFile_(const SubrunRecord& rec);
+
+	// DB output — background writer thread
+	std::string   subrun_record_db_connstr_;
+
+	static constexpr size_t kDbQueueMaxSize = 20;
+	std::queue<SubrunRecord>  db_queue_;
+	std::mutex                db_queue_mutex_;
+	std::condition_variable   db_queue_cv_;
+	std::atomic<bool>         db_writer_stop_{false};
+	std::thread               db_writer_thread_;
+
+	void dbWriterThread_();
+	void writeRecordToDb_(PGconn* conn, const SubrunRecord& rec);
+
+	// Push a copy of the current record to both outputs (called at subrun boundary)
+	void publishRecord_();
 
 	// The "getNext_" function is used to implement user-specific
 	// functionality; it's a mandatory override of the pure virtual
@@ -72,6 +138,216 @@ private:
 	DTCLib::DTC_EventWindowTag getCurrentEventWindowTag();
 };
 }  // namespace mu2e
+
+// ---------------------------------------------------------------------------
+// Helpers: build event_mode JSON string from a SubrunRecord
+// ---------------------------------------------------------------------------
+
+static std::string buildEventModeJson(const std::map<uint64_t, uint64_t>& counts)
+{
+	std::ostringstream oss;
+	oss << "{";
+	bool first = true;
+	for (auto const& kv : counts)
+	{
+		if (!first) oss << ",";
+		oss << "\"" << kv.first << "\":" << kv.second;
+		first = false;
+	}
+	oss << "}";
+	return oss.str();
+}
+
+// ---------------------------------------------------------------------------
+// File output
+// ---------------------------------------------------------------------------
+
+void mu2e::CFODataReceiver::openRecordFile_()
+{
+	if (subrun_record_dir_.empty()) return;
+
+	std::ostringstream fname;
+	fname << subrun_record_dir_;
+	if (subrun_record_dir_.back() != '/') fname << '/';
+	fname << "subrun_record_run" << std::setw(6) << std::setfill('0') << run_number() << ".csv";
+
+	subrun_record_file_.open(fname.str(), std::ios::app);
+	if (!subrun_record_file_.is_open())
+	{
+		TLOG(TLVL_WARNING) << "Could not open subrun record file: " << fname.str();
+		return;
+	}
+
+	subrun_record_file_.seekp(0, std::ios::end);
+	if (subrun_record_file_.tellp() == 0)
+	{
+		subrun_record_file_
+		    << "run_number,subrun_number"
+		    << ",n_events,n_on_spill,n_off_spill,n_null"
+		    << ",min_ewt,max_ewt"
+		    << ",start_time_unix,stop_time_unix"
+		    << ",event_mode_counts_json"
+		    << "\n";
+	}
+	TLOG(TLVL_DEBUG) << "Opened subrun record file: " << fname.str();
+}
+
+void mu2e::CFODataReceiver::writeRecordToFile_(const SubrunRecord& rec)
+{
+	if (!subrun_record_file_.is_open()) return;
+	if (rec.n_events == 0) return;
+
+	subrun_record_file_
+	    << run_number()
+	    << "," << rec.subrun_number
+	    << "," << rec.n_events
+	    << "," << rec.n_on_spill
+	    << "," << rec.n_off_spill
+	    << "," << rec.n_null
+	    << "," << rec.min_ewt
+	    << "," << rec.max_ewt
+	    << "," << rec.start_time_unix
+	    << "," << rec.stop_time_unix
+	    << ",\"" << buildEventModeJson(rec.event_mode_counts) << "\""
+	    << "\n";
+	subrun_record_file_.flush();
+
+	TLOG(TLVL_DEBUG) << "Wrote file record for subrun " << rec.subrun_number
+	                 << ": " << rec.n_events << " events"
+	                 << " (" << rec.n_on_spill << " on-spill, " << rec.n_off_spill << " off-spill)";
+}
+
+// ---------------------------------------------------------------------------
+// DB output — background writer thread
+// ---------------------------------------------------------------------------
+
+void mu2e::CFODataReceiver::writeRecordToDb_(PGconn* conn, const SubrunRecord& rec)
+{
+	if (rec.n_events == 0) return;
+
+	const std::string mode_json = buildEventModeJson(rec.event_mode_counts);
+
+	// Use parameterized query to avoid any injection issues
+	const std::string sql =
+	    "INSERT INTO test_sc.subrun "
+	    "(run, subrun, n_events, n_on_spill, n_off_spill, n_null, "
+	    " min_ewt, max_ewt, start_time_unix, stop_time_unix, event_mode_counts) "
+	    "VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11::jsonb) "
+	    "ON CONFLICT (run, subrun) DO UPDATE SET "
+	    "  n_events=EXCLUDED.n_events, n_on_spill=EXCLUDED.n_on_spill, "
+	    "  n_off_spill=EXCLUDED.n_off_spill, n_null=EXCLUDED.n_null, "
+	    "  min_ewt=EXCLUDED.min_ewt, max_ewt=EXCLUDED.max_ewt, "
+	    "  start_time_unix=EXCLUDED.start_time_unix, "
+	    "  stop_time_unix=EXCLUDED.stop_time_unix, "
+	    "  event_mode_counts=EXCLUDED.event_mode_counts";
+
+	const std::string p1  = std::to_string(run_number());
+	const std::string p2  = std::to_string(rec.subrun_number);
+	const std::string p3  = std::to_string(rec.n_events);
+	const std::string p4  = std::to_string(rec.n_on_spill);
+	const std::string p5  = std::to_string(rec.n_off_spill);
+	const std::string p6  = std::to_string(rec.n_null);
+	const std::string p7  = std::to_string(rec.min_ewt);
+	const std::string p8  = std::to_string(rec.max_ewt);
+	const std::string p9  = std::to_string(rec.start_time_unix);
+	const std::string p10 = std::to_string(rec.stop_time_unix);
+	const std::string p11 = mode_json;
+
+	const char* params[11] = { p1.c_str(), p2.c_str(), p3.c_str(), p4.c_str(), p5.c_str(),
+	                            p6.c_str(), p7.c_str(), p8.c_str(), p9.c_str(), p10.c_str(),
+	                            p11.c_str() };
+
+	PGresult* res = PQexecParams(conn, sql.c_str(), 11, nullptr, params, nullptr, nullptr, 0);
+
+	if (PQresultStatus(res) != PGRES_COMMAND_OK)
+		TLOG(TLVL_WARNING) << "DB insert failed for subrun " << rec.subrun_number
+		                   << ": " << PQresultErrorMessage(res);
+	else
+		TLOG(TLVL_DEBUG) << "DB record written for subrun " << rec.subrun_number;
+
+	PQclear(res);
+}
+
+void mu2e::CFODataReceiver::dbWriterThread_()
+{
+	if (subrun_record_db_connstr_.empty()) return;
+
+	PGconn* conn = PQconnectdb(subrun_record_db_connstr_.c_str());
+	if (PQstatus(conn) != CONNECTION_OK)
+	{
+		TLOG(TLVL_WARNING) << "DB connection failed: " << PQerrorMessage(conn)
+		                   << " — subrun records will not be written to DB";
+		PQfinish(conn);
+		// Drain the queue without writing so pushes don't pile up
+		while (true)
+		{
+			std::unique_lock<std::mutex> lock(db_queue_mutex_);
+			db_queue_cv_.wait(lock, [&]{ return !db_queue_.empty() || db_writer_stop_.load(); });
+			while (!db_queue_.empty()) db_queue_.pop();
+			if (db_writer_stop_.load()) break;
+		}
+		return;
+	}
+
+	TLOG(TLVL_DEBUG) << "DB writer thread connected";
+
+	while (true)
+	{
+		SubrunRecord rec;
+		{
+			std::unique_lock<std::mutex> lock(db_queue_mutex_);
+			db_queue_cv_.wait(lock, [&]{ return !db_queue_.empty() || db_writer_stop_.load(); });
+
+			if (db_queue_.empty()) break;  // stop_ set and queue drained
+
+			rec = std::move(db_queue_.front());
+			db_queue_.pop();
+		}
+
+		// Reconnect if connection was lost
+		if (PQstatus(conn) != CONNECTION_OK)
+		{
+			PQreset(conn);
+			if (PQstatus(conn) != CONNECTION_OK)
+			{
+				TLOG(TLVL_WARNING) << "DB reconnect failed, dropping subrun " << rec.subrun_number;
+				continue;
+			}
+		}
+
+		writeRecordToDb_(conn, rec);
+	}
+
+	PQfinish(conn);
+	TLOG(TLVL_DEBUG) << "DB writer thread exiting";
+}
+
+// ---------------------------------------------------------------------------
+// Publish: called at subrun boundary — copies record to file and DB queue
+// ---------------------------------------------------------------------------
+
+void mu2e::CFODataReceiver::publishRecord_()
+{
+	if (subrun_record_.n_events == 0) return;
+
+	writeRecordToFile_(subrun_record_);
+
+	if (!subrun_record_db_connstr_.empty())
+	{
+		std::unique_lock<std::mutex> lock(db_queue_mutex_);
+		if (db_queue_.size() >= kDbQueueMaxSize)
+		{
+			TLOG(TLVL_WARNING) << "DB queue full, dropping subrun record " << subrun_record_.subrun_number;
+		}
+		else
+		{
+			db_queue_.push(subrun_record_);
+			db_queue_cv_.notify_one();
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 
 mu2e::CFODataReceiver::~CFODataReceiver()
 {
@@ -101,20 +377,6 @@ bool mu2e::CFODataReceiver::getNext_(artdaq::FragmentPtrs& frags)
 
 	uint64_t z = 0;
 	DTCLib::DTC_EventWindowTag zero(z);
-
-	//--------------------------------------------------------------------------------
-	// temporary sub-run transition
-	//--------------------------------------------------------------------------------
-	if (rollover_transition_)
-	{
-		rollover_transition_ = false;
-		const auto last_timestamp = ewts_.rbegin()->first;
-		const auto next_subrun = 1 + (ev_counter() / rollover_subrun_interval_);
-		TLOG(TLVL_DEBUG + 31) << "getNext_ sending subrun transition to subrun " << next_subrun << " and timestamp " << last_timestamp + 1;
-		//                                                                                          next EWT   subrun number      ID
-		auto endOfSubrunFrag = artdaq::MetadataFragment::CreateEndOfSubrunFragment(my_rank, last_timestamp + 1, next_subrun, fragment_id());
-		frags.emplace_back(std::move(endOfSubrunFrag));
-	}
 
 	TLOG(TLVL_DEBUG + 34) << "getNext_ req";
 	auto start_time = std::chrono::steady_clock::now();
@@ -148,9 +410,27 @@ mu2e::CFODataReceiver::CFODataReceiver(fhicl::ParameterSet const& ps)
 	, print_packets_(ps.get<bool>("debug_print", false))
 	, throttle_usecs_(ps.get<size_t>("throttle_usecs", 0))  // in units of us
 	, rollover_subrun_interval_(ps.get<size_t>("rollover_subrun_interval", 20000))
-	, rollover_transition_(false)
 	, diagLevel_(ps.get<int>("diagLevel", 0))
+	, subrun_record_dir_(ps.get<std::string>("subrun_record_dir", ""))
+	, subrun_record_db_connstr_(ps.get<std::string>("subrun_record_db_connstr", ""))
 {
+	// If no explicit connstr, try to build one from environment variables
+	if (subrun_record_db_connstr_.empty())
+	{
+		const char* host   = std::getenv("OTSDAQ_RUNINFO_DATABASE_HOST");
+		const char* db     = std::getenv("OTSDAQ_RUNINFO_DATABASE");
+		const char* port   = std::getenv("OTSDAQ_RUNINFO_DATABASE_PORT");
+		const char* user   = std::getenv("OTSDAQ_RUNINFO_DATABASE_USER");
+		if (host && db && port && user)
+		{
+			std::ostringstream oss;
+			oss << "host=" << host << " port=" << port
+			    << " dbname=" << db << " user=" << user;
+			subrun_record_db_connstr_ = oss.str();
+			TLOG(TLVL_DEBUG) << "Built DB connstr from environment: " << subrun_record_db_connstr_;
+		}
+	}
+
 	// mode_ can still be overridden by environment!
 	theCFO_ = std::make_unique<CFOLib::CFO>(mode_,
 											ps.get<int>("cfo", -1),
@@ -174,6 +454,17 @@ mu2e::CFODataReceiver::CFODataReceiver(fhicl::ParameterSet const& ps)
 
 void mu2e::CFODataReceiver::stop()
 {
+	publishRecord_();
+	if (subrun_record_file_.is_open()) subrun_record_file_.close();
+
+	// Signal DB writer and give it up to 3 seconds to flush
+	if (db_writer_thread_.joinable())
+	{
+		db_writer_stop_.store(true);
+		db_queue_cv_.notify_one();
+		db_writer_thread_.join();  // already has a 3s deadline — see start()
+	}
+
 	ewts_.clear();
 	// if (skip_cfo_init_) return;  // skip any control of DTC
 }
@@ -182,6 +473,19 @@ void mu2e::CFODataReceiver::start()
 {
 	theCFO_->ReleaseAllBuffers(DTC_DMA_Engine_DAQ);
 	ewts_.clear();
+
+	subrun_record_.reset(subrun_number());
+	openRecordFile_();
+
+	// Start DB writer thread if we have a connection string
+	if (!subrun_record_db_connstr_.empty())
+	{
+		db_writer_stop_.store(false);
+		db_writer_thread_ = std::thread([this]()
+		{
+			dbWriterThread_();
+		});
+	}
 }
 
 bool mu2e::CFODataReceiver::getNextDTCFragment(artdaq::FragmentPtrs& frags, DTCLib::DTC_EventWindowTag ts_in)
@@ -246,14 +550,56 @@ bool mu2e::CFODataReceiver::getNextDTCFragment(artdaq::FragmentPtrs& frags, DTCL
 		metricMan->sendMetric("Average Event Size", evt->GetEventByteCount(), "Bytes", 3, artdaq::MetricMode::Average);
 		TLOG(TLVL_DEBUG + 26) << "Incrementing event counter";
 		ev_counter_inc();
-		//--------------------------------------------------------------------------------
-		// temporary sub-run transition
-		//--------------------------------------------------------------------------------
-		if (rollover_subrun_interval_ > 0 && ev_counter() % rollover_subrun_interval_ == 0 && fragment_id() == 0)
+
+		// Per-subrun accounting
 		{
-			TLOG(TLVL_DEBUG + 29) << "Identified the subrun rollover (timestamp = " << fragment_timestamp
-								  << " ev_counter = " << ev_counter() << ")";
-			rollover_transition_ = true;
+			const CFOLib::CFO_EventRecord& rec  = evt->GetEventRecord();
+			const DTCLib::DTC_EventMode   mode  = evt->GetEventMode();
+
+			if (rec.event_mode == 0)
+			{
+				++subrun_record_.n_null;
+			}
+			else
+			{
+				++subrun_record_.n_events;
+
+				if (fragment_timestamp < subrun_record_.min_ewt) subrun_record_.min_ewt = fragment_timestamp;
+				if (fragment_timestamp > subrun_record_.max_ewt) subrun_record_.max_ewt = fragment_timestamp;
+
+				if (mode.isOnSpillFlagSet())
+					++subrun_record_.n_on_spill;
+				else
+					++subrun_record_.n_off_spill;
+
+				const uint32_t hw_time = static_cast<uint32_t>(rec.linux_timestamp);
+				if (subrun_record_.start_time_unix == 0) subrun_record_.start_time_unix = hw_time;
+				subrun_record_.stop_time_unix = hw_time;
+			}
+
+			++subrun_record_.event_mode_counts[rec.event_mode];
+		}
+
+		//--------------------------------------------------------------------------------
+		// Sub-run transition: fire inline so the boundary is exact within the batch.
+		// Triggered by hardware subrun bit OR software event-count interval.
+		//--------------------------------------------------------------------------------
+		const bool hw_subrun_trigger  = (fragment_id() == 0) && evt->GetEventMode().isSubRunBitSet();
+		const bool sw_subrun_trigger  = (fragment_id() == 0) && (rollover_subrun_interval_ > 0)
+		                                && (ev_counter() % rollover_subrun_interval_ == 0);
+		if (hw_subrun_trigger || sw_subrun_trigger)
+		{
+			const auto next_subrun = subrun_record_.subrun_number + 1;
+			TLOG(TLVL_DEBUG + 29) << "Subrun transition (hw=" << hw_subrun_trigger
+			                      << " sw=" << sw_subrun_trigger
+			                      << ") at EWT=" << fragment_timestamp
+			                      << " ev_counter=" << ev_counter()
+			                      << " -> subrun " << next_subrun;
+			publishRecord_();
+			subrun_record_.reset(next_subrun);
+			//                                                                   next EWT             subrun       ID
+			frags.emplace_back(artdaq::MetadataFragment::CreateEndOfSubrunFragment(
+			    my_rank, fragment_timestamp + 1, next_subrun, fragment_id()));
 		}
 	}
 

--- a/artdaq-mu2e/Generators/CMakeLists.txt
+++ b/artdaq-mu2e/Generators/CMakeLists.txt
@@ -20,6 +20,7 @@ cet_build_plugin(CFODataReceiver artdaq::commandableGenerator
   mu2e-pcie-utils::DTCInterface
   mu2e-pcie-utils::CFOInterface
   artdaq_plugin_types::CommandableFragmentGenerator
+  pq
 )
 
 cet_build_plugin(CFOZmqReceiver artdaq::commandableGenerator

--- a/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
+++ b/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
@@ -176,7 +176,9 @@ mu2e::Mu2eSubEventReceiver::Mu2eSubEventReceiver(fhicl::ParameterSet const& ps)
 
 	if (skip_dtc_init_) 
 	{
+        TLOG(TLVL_ERROR) << "Before ReleaseAllBuffers" << std::endl;
 		theInterface_->ReleaseAllBuffers(DTC_DMA_Engine_DAQ);
+        TLOG(TLVL_ERROR) << "After ReleaseAllBuffers" << std::endl;
 		return; // skip any control of DTC	
 	}
 


### PR DESCRIPTION
Added CFO subrun handling and logging


# AI summary:
This pull request introduces a robust per-subrun record-keeping and reporting system to `CFODataReceiver_generator.cc`, including both file and database output, and integrates the necessary infrastructure to support it. The main changes add a new `SubrunRecord` structure, logic to collect and publish subrun metrics, and background database writing using PostgreSQL. Additionally, the build system is updated to link with the PostgreSQL client library.

### Subrun record-keeping and reporting

* Added a `SubrunRecord` struct to track per-subrun statistics, including event counts, time ranges, and event mode distributions, along with methods for resetting and updating these records.
* Implemented logic in `getNextDTCFragment` to update the subrun record for each event, and to publish (write) the record to file and/or database at subrun boundaries, triggered by hardware or software conditions.

### File and database output

* Added methods to write subrun records to a CSV file (`openRecordFile_`, `writeRecordToFile_`) and to a PostgreSQL database (`writeRecordToDb_`, `dbWriterThread_`), including a background writer thread for the database. The database connection string can be set via configuration or environment variables. [[1]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eR142-R351) [[2]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eL151-R433) [[3]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eR476-R488)
* Ensured clean startup and shutdown of the file and database output mechanisms in `start()` and `stop()`, including thread management and flushing. [[1]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eR457-R467) [[2]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eR476-R488)

### Build system

* Updated the CMake build for `CFODataReceiver` to link against the PostgreSQL client library (`pq`).

### Minor improvements and cleanup

* Removed the unused `rollover_transition_` mechanism, replacing it with inline subrun transition logic. [[1]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eL61-R132) [[2]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eL105-L118)
* Added additional debug logging and error handling throughout the new code paths. [[1]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eR142-R351) [[2]](diffhunk://#diff-b24f69466b558d1e6c1176a705a8cbb911186ce5736665452742cc98fb47255eL151-R433)

### Other

* Added temporary debug logging to `Mu2eSubEventReceiver_generator.cc` to help trace buffer release operations.