### PR TITLE
Crucial fix to allow again to run at higher rates

### DIFF
--- a/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
+++ b/artdaq-mu2e/Generators/Mu2eSubEventReceiver_generator.cc
@@ -274,6 +274,8 @@ bool mu2e::Mu2eSubEventReceiver::getNextDTCFragment(artdaq::FragmentPtrs& frags,
 	// GetSubEventData can return multiple EWTs, and we can assume that there is ONE DTC_SubEvent per EWT!
 	for (auto& subevt : data)
 	{
+		ts_out = subevt->GetEventWindowTag();
+		TLOG(TLVL_TRACE + 19) << "Processing subevent with timestamp " << ts_out.GetEventWindowTag(true);
 		size_t size_bytes = sizeof(DTCLib::DTC_EventHeader);
 		size_bytes += subevt->GetSubEventByteCount();
 		TLOG(TLVL_DEBUG + 20) << "Size of event will be " << static_cast<int>(size_bytes) << "B";


### PR DESCRIPTION
I think this most be related to an underlying recent-ish change in `mu2e-pcie-utils`. Now, `GetSubEventData` seems to return multiple events when running above ~4kHz. Likely always intended, we have a corresponding comment in the code, but not reflected in the actual code of of the Mu2eSubEventReciever. As far as I see, this modification fixes this. 